### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/build-base-extra.yaml
+++ b/.github/workflows/build-base-extra.yaml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Publish base-extra to Docker Hub
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: facilebio/facilebio_base_extra
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/build-base.yaml
+++ b/.github/workflows/build-base.yaml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Publish base to Docker Hub
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: facilebio/facilebio_base
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/build-facilebio.yaml
+++ b/.github/workflows/build-facilebio.yaml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Publish facilebio to Docker Hub
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: facilebio/facilebio
           username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore